### PR TITLE
Use a more robust check for process completion

### DIFF
--- a/Denovo_Signature_Discovery/scripts/1_Signature_derivation_from_input_matrix.sh
+++ b/Denovo_Signature_Discovery/scripts/1_Signature_derivation_from_input_matrix.sh
@@ -1,4 +1,4 @@
-#!
+#!/bin/bash
 
 #### Deriving signatures from input matrix
 
@@ -73,20 +73,19 @@ for ITER in $(seq 1 $ITERS); do
 
     echo $ITER
 
+    pids=()
     for PAR in $(seq 1 $PARALLEL); do
 
         UUID=$(cat /dev/urandom | tr -dc 'A-Z0-9' | fold -w 6 | head -n 1)
         OUTPATH="${UUID}"
         mkdir -p $OUTPATH
         python $SCRIPTPATH --data $INPUTMATRIX --max_iter=$MAXITER --output_dir $OUTPATH $REGULARISATIONS --labeled --K0 $K0 > ${OUTPATH}/${UUID}_log.txt &
+        pids[${PAR}]=$!
 
     done
 
-    sleep 4
-    PYRUN=`nvidia-smi | grep -c python`
-    while [[ $PYRUN != 0 ]]; do
-        sleep 2
-        PYRUN=`nvidia-smi | grep -c python`
+    for pid in ${pids[*]}; do
+        wait $pid
     done
 
 done


### PR DESCRIPTION
The approach used in the script assumes that the GPU is exclusively used
by the invoker. However, some places (like mine) treat GPUs as shared
resources: different users can use the same GPU. Therefore, the single
presence of a process called `python`in the process list, even if not created 
by the caller, will cause the script to loop needlessly without doing anything.

This change creates an array where the PIDs for each of the calculations
are stored (using `$!`), then uses `wait` to ensure that all the processes have 
ended before moving on to the next iteration.

**Note**: This adds a dependency on bash (but I'm not sure if this
script is POSIX-compatible) and requires a reasonably recent version of
it (tested with 5.0 on Debian).